### PR TITLE
Fix for CRD creation

### DIFF
--- a/stable/prometheus-operator/templates/exporters/alertmanager/crd-alertmanager.yaml
+++ b/stable/prometheus-operator/templates/exporters/alertmanager/crd-alertmanager.yaml
@@ -7,6 +7,7 @@ metadata:
   name: alertmanagers.monitoring.coreos.com
   annotations:
     "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: monitoring.coreos.com
   names:

--- a/stable/prometheus-operator/templates/exporters/prometheus-operator/cleanup-crds.yaml
+++ b/stable/prometheus-operator/templates/exporters/prometheus-operator/cleanup-crds.yaml
@@ -4,7 +4,7 @@ metadata:
   name: prometheus-operator-cleanup-crds
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": pre-delete
+    "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": hook-succeeded
     "helm.sh/hook-weight": "3"
   labels:

--- a/stable/prometheus-operator/templates/exporters/prometheus-operator/crd-prometheus.yaml
+++ b/stable/prometheus-operator/templates/exporters/prometheus-operator/crd-prometheus.yaml
@@ -7,6 +7,7 @@ metadata:
   name: prometheuses.monitoring.coreos.com
   annotations:
     "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: monitoring.coreos.com
   names:

--- a/stable/prometheus-operator/templates/exporters/prometheus-operator/crd-prometheusrules.yaml
+++ b/stable/prometheus-operator/templates/exporters/prometheus-operator/crd-prometheusrules.yaml
@@ -7,6 +7,7 @@ metadata:
   name: prometheusrules.monitoring.coreos.com
   annotations:
     "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: monitoring.coreos.com
   names:

--- a/stable/prometheus-operator/templates/exporters/prometheus-operator/crd-servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/prometheus-operator/crd-servicemonitor.yaml
@@ -7,6 +7,7 @@ metadata:
   name: servicemonitors.monitoring.coreos.com
   annotations:
     "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: monitoring.coreos.com
   names:


### PR DESCRIPTION
I think the issue is that the cluster is "dirty" and has existing CRDs in there already that need to be cleaned out, but I'm not sure

The delete hook needs to be run `post-delete` so the dependencies that use the CRDs are removed first.